### PR TITLE
Add support for HTTPS connection to WebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Add the following environment variables to your qBittorrent container:
 - `DOCKER_MODS=ghcr.io/techclusterhq/qbt-portchecker:main`
 - `PORTCHECKER_GLUETUN_API_KEY=API KEY HERE`: Instructions below
 - `PORTCHECKER_GLUETUN_CONTROL_SERVER_PORT=8000`: Optional, default 8000: the port the gluetun control server can be reached at
-- `PORTCHECKER_SLEEP=180`: Optional, default 180: how long the script should wait between each check
+- `PORTCHECKER_SLEEP=120`: Optional, default 120: how long the script should wait between each check
 - `PORTCHECKER_KILL_ON_NOT_CONNECTABLE=true`: Optional, default true: whether or not to restart qBittorrent if the port stops being connectable
+- `PORTCHECKER_HTTPS=false`: Optional, default false: Set to `true` if you configured qBittorrent WebUI to use HTTPS.
 
 > [!NOTE]  
 > If you are already using another docker mod with your qBittorrent container you have to combine both into one DOCKER_MODS variable, seperated by a pipe:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Add the following environment variables to your qBittorrent container:
 - `FIREWALL_VPN_INPUT_PORTS=12345`: Set this to your forwarded vpn port
 - `PORTCHECKER_SLEEP=180`: Optional, default 180: how long the script should wait between each check
 - `PORTCHECKER_KILL_ON_NOT_CONNECTABLE=true`: Optional, default true: whether or not to restart qBittorrent if the port stops being connectable
+- `PORTCHECKER_HTTPS=false`: Optional, default false: Set to `true` if you configured qBittorrent WebUI to use HTTPS.
 
 If it exists, remove the `TORRENTING_PORT` variable completely.
 

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-qbittorrent-portchecker/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-qbittorrent-portchecker/run
@@ -11,12 +11,23 @@ GLUETUN_PORT=${PORTCHECKER_GLUETUN_CONTROL_SERVER_PORT:-8000}
 SLEEP_COMPLETE=${PORTCHECKER_SLEEP:-120}
 KILL_ON_NOT_CONNECTABLE=${PORTCHECKER_KILL_ON_NOT_CONNECTABLE:-true}
 FIREWALL_VPN_INPUT_PORTS=${FIREWALL_VPN_INPUT_PORTS} # permanently set this port as the forwarded port
+HTTPS=${PORTCHECKER_HTTPS:-false}
 
 VAR_UP=true
 
+SCHEME="http"
+WGET_OPTIONS="--server-response --spider -T 5 -t 1"
+CURL_OPTIONS="--silent"
+
+if [[ "$HTTPS" == "true" ]]; then
+    SCHEME="https"
+    WGET_OPTIONS="$WGET_OPTIONS --no-check-certificate"
+    CURL_OPTIONS="$CURL_OPTIONS --insecure"
+fi
+
 while :; do
 
-    HTTP_STATUS=$(wget -T 5 -t 1 --server-response --spider "http://localhost:${WEBUI_PORT}" 2>&1 | awk '/HTTP\// {print $2}')
+    HTTP_STATUS=$(wget $WGET_OPTIONS "${SCHEME}://localhost:${WEBUI_PORT}" 2>&1 | awk '/HTTP\// {print $2}')
 
     if [[ "200" == "$HTTP_STATUS" ]]; then
         log "web ui online"
@@ -42,7 +53,7 @@ while :; do
             continue
         fi
     
-        PORT=$(wget -T 5 -t 1 -qO- "http://localhost:${WEBUI_PORT}/api/v2/app/preferences" | jq ".listen_port")
+        PORT=$(wget -T 5 -t 1 -qO- ${HTTPS:+--no-check-certificate} "${SCHEME}://localhost:${WEBUI_PORT}/api/v2/app/preferences" | jq ".listen_port")
     
         if [[ "" == "$NEW_PORT" ]]; then
             log "no port in file or file not found"
@@ -52,7 +63,7 @@ while :; do
             [[ true == "$VAR_UP" ]] && log "port did not change (port: $PORT)"
         else
             log "detected port changed: old: $PORT, new: $NEW_PORT"
-            curl --silent --request POST --url "http://localhost:${WEBUI_PORT}/api/v2/app/setPreferences" --data "json={\"listen_port\": $NEW_PORT}"
+            curl $CURL_OPTIONS --request POST --url "${SCHEME}://localhost:${WEBUI_PORT}/api/v2/app/setPreferences" --data "json={\"listen_port\": $NEW_PORT}"
     
             if [[ $? -eq 0 ]]; then
                 log "port updated to $NEW_PORT successfully"

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-qbittorrent-portchecker/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-qbittorrent-portchecker/run
@@ -25,12 +25,13 @@ if [[ "$HTTPS" == "true" ]]; then
     CURL_OPTIONS="$CURL_OPTIONS --insecure"
 fi
 
+log "Waiting for WebUI to become available at ${SCHEME}://localhost:${WEBUI_PORT}"
 while :; do
 
     HTTP_STATUS=$(wget $WGET_OPTIONS "${SCHEME}://localhost:${WEBUI_PORT}" 2>&1 | awk '/HTTP\// {print $2}')
 
     if [[ "200" == "$HTTP_STATUS" ]]; then
-        log "web ui online"
+        log "WebUI online at ${SCHEME}://localhost:${WEBUI_PORT}"
         break
     fi
 


### PR DESCRIPTION
If HTTPS is used for the WebUI, the portchecker never gets past the HTTP_STATUS check. Added logic to handle that.

Also noticed the script defaults PORTCHECKER_SLEEP to 120, but the README said 180. I updated the README to match, but you could change it to whichever way you may see fit.

+ a line of log was added and the other changed at the beginning of the mod to indicate the status a little more.